### PR TITLE
Add initial audit.js and pipeline.js scripts

### DIFF
--- a/audit.js
+++ b/audit.js
@@ -1,0 +1,77 @@
+import { writeFile } from 'node:fs/promises';
+import { resolve, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SingleBar,Presets } from 'cli-progress';
+import { glob } from 'glob';
+import pLimit from 'p-limit';
+import draco3d from 'draco3dgltf';
+import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
+import { NodeIO } from '@gltf-transform/core';
+import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
+import { inspect } from '@gltf-transform/functions';
+
+// Configure glTF I/O.
+
+await MeshoptDecoder.ready;
+await MeshoptEncoder.ready;
+
+const io = new NodeIO()
+	.registerExtensions(ALL_EXTENSIONS)
+	.registerDependencies({
+		'draco3d.decoder': await draco3d.createDecoderModule(),
+		'draco3d.encoder': await draco3d.createEncoderModule(),
+		'meshopt.decoder': MeshoptDecoder,
+		'meshopt.encoder': MeshoptEncoder,
+	});
+
+// Set up search on project directory.
+
+const limit = pLimit(4); // process up to 4 models at a time.
+const workspacePath = dirname(fileURLToPath(import.meta.url));
+const paths = await glob(resolve(workspacePath, '**/*.{glb,gltf}'));
+
+const documentPromises = paths.map((path) => limit(async () => {
+	return [path, await io.read(path)];
+}));
+
+const bar = new SingleBar({}, Presets.shades_classic);
+bar.start(paths.length, 0);
+
+// Iterate over all models and create report.
+
+const header = 'name,nodes,meshes,materials,vertices,keyframes';
+const reportRows = [];
+
+for await (const [path, document] of documentPromises) {
+	const report = inspect(document);
+	const name = basename(path);
+	const nodes = document.getRoot().listNodes().length;
+	const meshes = sum(report.meshes, 'primitives');
+	const materials = document.getRoot().listMaterials().length;
+	const vertices = sum(report.meshes, 'vertices');
+	const keyframes = sum(report.animations, 'keyframes');
+	reportRows.push(`${name},${nodes},${meshes},${materials},${vertices},${keyframes}`);
+	bar.increment();
+}
+
+bar.stop();
+
+// Write output
+
+console.log('🗄️  Writing audit.csv...');
+
+reportRows.sort();
+const csvContent = header + '\n' + reportRows.join('\n');
+await writeFile(resolve(workspacePath, 'audit.csv'), csvContent);
+
+console.log('🍻  Done!');
+
+//////////// Utilities ////////////
+
+function sum(report, key) {
+	let sum = 0;
+	for (const prop of report.properties) {
+		sum += prop[key];
+	}
+	return sum;
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "type": "module",
+  "dependencies": {
+    "@gltf-transform/core": "^3.4.4",
+    "@gltf-transform/extensions": "^3.4.4",
+    "@gltf-transform/functions": "^3.4.4",
+    "cli-progress": "^3.12.0",
+    "draco3dgltf": "^1.5.6",
+    "glob": "^10.3.1",
+    "meshoptimizer": "^0.19.0",
+    "p-limit": "^4.0.0"
+  }
+}

--- a/pipeline.js
+++ b/pipeline.js
@@ -1,0 +1,64 @@
+import { resolve, dirname, parse } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { SingleBar,Presets } from 'cli-progress';
+import { glob } from 'glob';
+import pLimit from 'p-limit';
+import draco3d from 'draco3dgltf';
+import { MeshoptDecoder, MeshoptEncoder } from 'meshoptimizer';
+import { NodeIO, Logger } from '@gltf-transform/core';
+import { ALL_EXTENSIONS } from '@gltf-transform/extensions';
+import { dedup, flatten, dequantize, join, weld, resample, prune, sparse, draco } from '@gltf-transform/functions';
+
+// Configure glTF I/O.
+
+await MeshoptDecoder.ready;
+await MeshoptEncoder.ready;
+
+const io = new NodeIO()
+	.setLogger(new Logger(Logger.Verbosity.WARN))
+	.registerExtensions(ALL_EXTENSIONS)
+	.registerDependencies({
+		'draco3d.decoder': await draco3d.createDecoderModule(),
+		'draco3d.encoder': await draco3d.createEncoderModule(),
+		'meshopt.decoder': MeshoptDecoder,
+		'meshopt.encoder': MeshoptEncoder,
+	});
+
+// Set up search on project directory.
+
+const limit = pLimit(4); // process up to 4 models at a time.
+const workspacePath = dirname(fileURLToPath(import.meta.url));
+const paths = (await glob(resolve(workspacePath, '**/*.{glb,gltf}')))
+	.filter((path) => !parse(path).name.endsWith('_opt'));
+
+const bar = new SingleBar({}, Presets.shades_classic);
+bar.start(paths.length, 0);
+
+// Iterate over all models and process.
+
+await Promise.all(paths.map((path) => limit(async () => {
+	const document = await io.read(path);
+
+	await document.transform(
+		dedup(),
+		flatten(),
+		dequantize(),
+		join(),
+		weld(),
+		resample(),
+		prune({ keepAttributes: false, keepLeaves: false }),
+		sparse(),
+		draco()
+	);
+
+	const name = parse(path).name + '_opt.glb';
+	await io.write(resolve(workspacePath, name), document);
+
+	bar.increment();
+})));
+
+bar.stop();
+
+console.log('🍻  Done!');
+
+//////////// Utilities ////////////


### PR DESCRIPTION
Not sure if this is something it would make sense to actually merge in this repository, or if the scripts would be better located elsewhere? Mostly just opening a draft PR to start discussion!

Summary:

- Adds `audit.js` file that scans all glTF models in the directory and creates an `audit.csv` report with statistics about each.
- Adds `pipeline.js` file that runs selected optimizations for every glTF model in the directory, and creates a new optimized file, e.g. `car.glb` → `car_opt.glb`.

Dependencies are defined in `package.json`, so steps to run either script would be:

```
# install
npm install

# audit
node ./audit.js

# pipeline
node ./pipeline.js

# reset
rm  **/*_opt.glb
```

Ideally the input files would *not* already be Draco compressed, since running them through any pipeline afterward is a bit lossy.